### PR TITLE
Switch LiquidacionRepository to EF Core

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.EntityFrameworkCore;
+using CFDI.Data.Contexts;
 using Nomina.WorkerTimbrado;
 using Nomina.WorkerTimbrado.Models;
 using Nomina.WorkerTimbrado.Services;
@@ -18,11 +20,13 @@ var builder = Host.CreateDefaultBuilder(args)
         }).AddTransientHttpErrorPolicy(builder =>
             builder.WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(Math.Pow(2, retry))));
 
-        services.AddTransient<LiquidacionRepository>(sp =>
+        services.AddDbContext<CfdiDbContext>((sp, options) =>
         {
             var settings = sp.GetRequiredService<IOptions<WorkerSettings>>().Value;
-            return new LiquidacionRepository(settings.ConnectionString);
+            options.UseSqlServer(settings.ConnectionString);
         });
+
+        services.AddTransient<LiquidacionRepository>();
 
         services.AddHostedService<Worker>();
     });

--- a/Services/LiquidacionRepository.cs
+++ b/Services/LiquidacionRepository.cs
@@ -1,109 +1,73 @@
-using System.Data;
-using System.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using CFDI.Data.Contexts;
 using Nomina.WorkerTimbrado.Models;
 
 namespace Nomina.WorkerTimbrado.Services
 {
     public class LiquidacionRepository
     {
-        private readonly string _connectionString;
+        private readonly CfdiDbContext _context;
 
-        public LiquidacionRepository(string connectionString)
+        public LiquidacionRepository(CfdiDbContext context)
         {
-            _connectionString = connectionString;
+            _context = context;
         }
-
-        private SqlConnection CreateConnection()
-            => new SqlConnection(_connectionString);
 
         public async Task<List<Liquidacion>> GetPendientesAsync(int batchSize, CancellationToken ct)
         {
-            var list = new List<Liquidacion>();
-            const string query = @"SELECT TOP(@BatchSize) IdLiquidacion, IdCompania, Intentos, UltimoIntento
-                                    FROM cfdi.liquidacionOperador
-                                    WHERE Estatus = 0
-                                      AND (FechaProximoIntento IS NULL OR FechaProximoIntento <= SYSUTCDATETIME())
-                                    ORDER BY FechaRegistro";
-            using var conn = CreateConnection();
-            using var cmd = new SqlCommand(query, conn);
-            cmd.Parameters.AddWithValue("@BatchSize", batchSize);
-            await conn.OpenAsync(ct);
-            using var reader = await cmd.ExecuteReaderAsync(ct);
-            while (await reader.ReadAsync(ct))
-            {
-                list.Add(new Liquidacion
+            var now = DateTime.UtcNow;
+
+            return await _context.liquidacionOperadors.AsNoTracking()
+                .Where(l => l.Estatus == 0 && (l.FechaProximoIntento == null || l.FechaProximoIntento <= now))
+                .OrderBy(l => l.FechaRegistro)
+                .Select(l => new Liquidacion
                 {
-                    IdLiquidacion = reader.GetInt32(0),
-                    IdCompania = reader.GetInt32(1),
-                    Intentos = reader.GetInt32(2),
-                    UltimoIntento = reader.GetInt16(3)
-                });
-            }
-            return list;
+                    IdLiquidacion = l.IdLiquidacion,
+                    IdCompania = l.IdCompania,
+                    Intentos = l.Intentos,
+                    UltimoIntento = l.UltimoIntento
+                })
+                .Take(batchSize)
+                .ToListAsync(ct);
         }
 
         public async Task<bool> MarcarEnProcesoAsync(Liquidacion liq, CancellationToken ct)
         {
-            const string update = @"UPDATE cfdi.liquidacionOperador
-                                     SET Estatus = 1,
-                                         Intentos = Intentos + 1,
-                                         UltimoIntento = Intentos + 1
-                                   WHERE IdLiquidacion = @IdLiquidacion
-                                     AND IdCompania = @IdCompania
-                                     AND Estatus = 0";
-            using var conn = CreateConnection();
-            using var cmd = new SqlCommand(update, conn);
-            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
-            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
-            await conn.OpenAsync(ct);
-            var rows = await cmd.ExecuteNonQueryAsync(ct);
+            var rows = await _context.liquidacionOperadors
+                .Where(l => l.IdLiquidacion == liq.IdLiquidacion && l.IdCompania == liq.IdCompania && l.Estatus == 0)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(l => l.Estatus, (byte)1)
+                    .SetProperty(l => l.Intentos, l => l.Intentos + 1)
+                    .SetProperty(l => l.UltimoIntento, l => l.Intentos + 1), ct);
+
             return rows > 0;
         }
 
         public async Task SetRequiereRevisionAsync(Liquidacion liq, CancellationToken ct)
         {
-            const string update = @"UPDATE cfdi.liquidacionOperador
-                                     SET Estatus = 6
-                                   WHERE IdLiquidacion = @IdLiquidacion
-                                     AND IdCompania = @IdCompania";
-            using var conn = CreateConnection();
-            using var cmd = new SqlCommand(update, conn);
-            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
-            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
-            await conn.OpenAsync(ct);
-            await cmd.ExecuteNonQueryAsync(ct);
+            await _context.liquidacionOperadors
+                .Where(l => l.IdLiquidacion == liq.IdLiquidacion && l.IdCompania == liq.IdCompania)
+                .ExecuteUpdateAsync(s => s.SetProperty(l => l.Estatus, (byte)6), ct);
         }
 
         public async Task SetErrorTransitorioAsync(Liquidacion liq, int backoffMinutes, CancellationToken ct)
         {
-            const string update = @"UPDATE cfdi.liquidacionOperador
-                                     SET Estatus = 4,
-                                         FechaProximoIntento = DATEADD(MINUTE, @Backoff, SYSUTCDATETIME())
-                                   WHERE IdLiquidacion = @IdLiquidacion
-                                     AND IdCompania = @IdCompania";
-            using var conn = CreateConnection();
-            using var cmd = new SqlCommand(update, conn);
-            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
-            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
-            cmd.Parameters.AddWithValue("@Backoff", backoffMinutes);
-            await conn.OpenAsync(ct);
-            await cmd.ExecuteNonQueryAsync(ct);
+            var next = DateTime.UtcNow.AddMinutes(backoffMinutes);
+
+            await _context.liquidacionOperadors
+                .Where(l => l.IdLiquidacion == liq.IdLiquidacion && l.IdCompania == liq.IdCompania)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(l => l.Estatus, (byte)4)
+                    .SetProperty(l => l.FechaProximoIntento, next), ct);
         }
 
         public async Task SetErrorAsync(Liquidacion liq, int status, string message, CancellationToken ct)
         {
-            const string update = @"UPDATE cfdi.liquidacionOperador
-                                     SET Estatus = @Status, MensajeCorto = @Mensaje
-                                   WHERE IdLiquidacion = @IdLiquidacion
-                                     AND IdCompania = @IdCompania";
-            using var conn = CreateConnection();
-            using var cmd = new SqlCommand(update, conn);
-            cmd.Parameters.AddWithValue("@Status", status);
-            cmd.Parameters.AddWithValue("@Mensaje", message);
-            cmd.Parameters.AddWithValue("@IdLiquidacion", liq.IdLiquidacion);
-            cmd.Parameters.AddWithValue("@IdCompania", liq.IdCompania);
-            await conn.OpenAsync(ct);
-            await cmd.ExecuteNonQueryAsync(ct);
+            await _context.liquidacionOperadors
+                .Where(l => l.IdLiquidacion == liq.IdLiquidacion && l.IdCompania == liq.IdCompania)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(l => l.Estatus, (byte)status)
+                    .SetProperty(l => l.MensajeCorto, message), ct);
         }
     }
 }

--- a/TimbradoNominaService.csproj
+++ b/TimbradoNominaService.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- refactor `LiquidacionRepository` to use `CfdiDbContext` and EF Core
- register `CfdiDbContext` in `Program.cs`
- remove obsolete `System.Data.SqlClient` package

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a3a7bb04832f86c140a05d033dc1