### PR TITLE
Improve TimbradoApiClient for new endpoint

### DIFF
--- a/TimbradoNominaDataAccess/TimbradoNominaDataAccess.csproj
+++ b/TimbradoNominaDataAccess/TimbradoNominaDataAccess.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\libs\Cfdi.Data\CFDI.Data.csproj" />
     <ProjectReference Include="..\libs\Utils\Hg.Utils.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- refine TimbradoApiClient to send `idCompania` and `noLiquidacion`
- add query helper package to data access project

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f513b5108832fbef69f8c8defd213